### PR TITLE
chore(project): update project setting

### DIFF
--- a/.idea/caip-js.iml
+++ b/.idea/caip-js.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.vscode" />
+      <excludePattern pattern="*.turbo*" />
+      <excludePattern pattern="*dist*" />
+      <excludePattern pattern="*generated" />
+      <excludePattern pattern="*coverage" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/caip-js.iml" filepath="$PROJECT_DIR$/.idea/caip-js.iml" />
+    </modules>
+  </component>
+</project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 Pedro Gomes
+Copyright (c) 2023 Levain
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# caip [![npm version](https://badge.fury.io/js/caip.svg)](https://badge.fury.io/js/caip)
+# caip-js [![npm version](https://badge.fury.io/js/caip-js.svg)](https://badge.fury.io/js/caip-js)
 
-CAIP standard utils
+Levain fork of `caip-js` released as caip-js. This fork is intended to fast-track PRs and fixes to the original repo.
 
 ## ChainId (CAIP-2)
 

--- a/package.json
+++ b/package.json
@@ -1,20 +1,7 @@
 {
   "name": "caip",
-  "description": "CAIP standard utils",
   "version": "1.1.0",
-  "author": "Pedro Gomes <github.com/pedrouid>",
   "license": "MIT",
-  "keywords": [
-    "caip",
-    "blockchain",
-    "standard",
-    "chain-agnostic",
-    "parse",
-    "format",
-    "chainId",
-    "accountId",
-    "assetId"
-  ],
   "files": [
     "dist"
   ],
@@ -29,13 +16,13 @@
       "require": "./dist/index.js"
     }
   },
-  "homepage": "https://github.com/pedrouid/caip-js",
+  "homepage": "https://github.com/levain-dev/caip-js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pedrouid/caip-js.git"
+    "url": "git+https://github.com/levain-dev/caip-js.git"
   },
   "bugs": {
-    "url": "https://github.com/pedrouid/caip-js/issues"
+    "url": "https://github.com/levain-dev/caip-js/issues"
   },
   "scripts": {
     "start": "tsdx watch",
@@ -65,5 +52,6 @@
     "semi": true,
     "singleQuote": false,
     "trailingComma": "es5"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Levain fork of `caip-js` released as caip-js. This fork is intended to fast-track PRs and fixes to the original repo.