### PR TITLE
chore: export assetName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./account";
 export * from "./chain";
 export * from "./assetType";
 export * from "./assetId";
+export * from "./assetName";


### PR DESCRIPTION
#### What this PR does
A quick change to export AssetName

#### Why

Prevent downstream packages from having to import from dist

```ts
import { AssetName } from 'caip/dist/assetName';
```
